### PR TITLE
Changed the start of the traversal generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ t = Trie(iterable='list or tuple')
     - Time complexity: O(1)
 - **remove(string):** Remove the given string from the Trie tree. Raises a TypeError if given a non-string value. Raises a ValueError if the string is not in the tree.
     - Time complexity: O(k) - where k is the length of the string
-- **traversal(start):** Get an depth-first traversal generator of the Trie tree. Starting traversal from an empty string returns a traversal of the entire Trie tree. Starting with a non-empty string will yield that string first, then children as individual letters. Raises a TypeError if given a non-string value.
+- **traversal(start):** Get an depth-first traversal generator of the Trie tree. Starting traversal from an empty string returns a traversal of the entire Trie tree. Starting with a non-empty string will yield only the children as individual letters. Raises a TypeError if given a non-string value.
     - Time complexity: O(n)
 
 ## Resources

--- a/src/test_trie.py
+++ b/src/test_trie.py
@@ -293,7 +293,7 @@ def test_inserting_and_removing_from_trie_works(empty_trie):
 def test_traversal_from_non_string_raises_error(small_trie):
     """Test that traversal from non-string raises a TypeError."""
     with pytest.raises(TypeError):
-        next(small_trie.traversal(10))
+        small_trie.traversal(10)
 
 
 def test_traversal_of_empty_trie_is_empty(empty_trie):
@@ -305,15 +305,15 @@ def test_traversal_of_empty_trie_is_empty(empty_trie):
 def test_traversal_from_string_not_in_trie_only_has_string(small_trie):
     """Test that traversal from string not in trie only has start string."""
     order = [x for x in small_trie.traversal('z')]
-    assert order == ['z']
+    assert order == []
 
 
 @pytest.mark.parametrize(
     'trie, letter, sol',
-    [(small_trie(), 'o', list('ormond')),
-     (small_trie(), 'l', list('lycopodiumenitively')),
-     (small_trie(), 'u', list('unidealisticretainedpleviableamused')),
-     (small_trie(), 'w', list('whirlpuff'))])
+    [(small_trie(), 'o', list('rmond')),
+     (small_trie(), 'l', list('ycopodiumenitively')),
+     (small_trie(), 'u', list('nidealisticretainedpleviableamused')),
+     (small_trie(), 'w', list('hirlpuff'))])
 def test_traversal_from_single_letter_has_entire_branch(trie, letter, sol):
     """Test that traversal from a single letter has branch of trie."""
     order = [x for x in trie.traversal(letter)]
@@ -324,13 +324,14 @@ def test_traversal_from_single_letter_has_entire_branch(trie, letter, sol):
 
 def test_traversal_from_longer_string_has_string_as_first_value(small_trie):
     """Test that traversal from a longer string has the string first."""
-    assert next(small_trie.traversal('unre')) == 'unre'
+    first = next(small_trie.traversal('unre'))
+    assert first == 'p' or first == 't'
 
 
 def test_traversal_from_longer_string_has_entire_branch(small_trie):
     """Test that traversal from a longer string has the entire branch."""
     order = [x for x in small_trie.traversal('unre')]
-    sol = ['unre', 't', 'a', 'i', 'n', 'e', 'd', 'p', 'l',
+    sol = ['t', 'a', 'i', 'n', 'e', 'd', 'p', 'l',
            'e', 'v', 'i', 'a', 'b', 'l', 'e']
 
     if sys.version_info.major == 3:
@@ -341,11 +342,11 @@ def test_traversal_from_longer_string_has_entire_branch(small_trie):
 def test_traversal_from_substring_has_no_extra_characters(small_trie):
     """Test that traversal from a substring has no extra characters."""
     order = [x for x in small_trie.traversal('whirl')]
-    assert order == ['whirl', 'p', 'u', 'f', 'f']
+    assert order == ['p', 'u', 'f', 'f']
 
 
 def test_traversal_with_empty_string_has_full_traversal(small_trie):
-    """Test that traversal from an empty string gets full traversal of the trie."""
+    """Test that traversal from an empty string gets full traversal of trie."""
     order = [x for x in small_trie.traversal('')]
     sol = list('whirlpufflycopodiumenitivelydiblastulaantenatihrapurpuringonis\
 tascaticooktricrotousunidealisticretainedpleviableamusedcacopharyngiahimakummu\

--- a/src/trie.py
+++ b/src/trie.py
@@ -91,27 +91,26 @@ class Trie(object):
 
         Starting traversal from an empty string returns a traversal
         of the entire Trie tree yielding individual letters. Starting
-        with a non-empty string will yield that string first, then
-        children as individual letters.
+        with a non-empty string will yield only the children as
+        individual letters.
         """
         if not isinstance(start, str):
             raise TypeError('Can only traverse the trie from strings.')
 
         def dive(node, first):
+            if not node:
+                return
             if node.val != '*' and node.val != '$' and not first:
                 yield node.val
             for ch in node.children:
                 for val in dive(node.children[ch], False):
                     yield val
 
-        if start:
-            yield start
-
         curr = self.root
         for ch in start:
             if ch not in curr.children:
-                return
+                curr = None
+                break
             curr = curr.children[ch]
 
-        for val in dive(curr, True):
-            yield val
+        return dive(curr, True)


### PR DESCRIPTION
The first value yielded from the generator is now the first child, not the starting string. That is, the starting string is not included in the generator. Also fixed the tests to reflect this.